### PR TITLE
[DB]: Created seeders for Roles

### DIFF
--- a/database/seeders/20221102205203-Role.js
+++ b/database/seeders/20221102205203-Role.js
@@ -1,0 +1,35 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    /**
+     * Add seed commands here.
+     */
+
+    await queryInterface.bulkInsert(
+      "Roles",
+      [
+        {
+          name: "Admin",
+          description: "A user with special privileges",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          name: "User",
+          description: "App user",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {}
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add commands to revert seed here.
+     */
+    await queryInterface.bulkDelete("Roles", null, {});
+  },
+};


### PR DESCRIPTION
## Jira Ticket

- [WA-26]

## Description
Created seeders for the table Roles, use the following command to run them:
npx sequelize db:seed:all

AS: Administrator
I Want: to populate the database table Roles
To: test the API.

## Evidence:
![Roles-seed](https://user-images.githubusercontent.com/112339651/199772617-52af6e52-5fe0-4d9a-a0b2-4f1709e30350.png)

