### PR TITLE
[DB] Created seeders for Categories

### DIFF
--- a/database/seeders/20221107164433-Category.js
+++ b/database/seeders/20221107164433-Category.js
@@ -1,0 +1,34 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    /**
+     * Add seed commands here.
+     */
+    await queryInterface.bulkInsert(
+      'Categories',
+      [
+        {
+          name: 'Income',
+          description: 'An amount of money a user receives into the account',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          name: 'Outcome',
+          description: 'An amount of money a user needs to do or buy something',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {}
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add commands to revert seed here.
+     */
+    await queryInterface.bulkDelete('Categories', null, {});
+  },
+};


### PR DESCRIPTION
## Jira Ticket

- [WA-27]

## Description
Created seeders for the table Categories, use the following command to run them:
npx sequelize db:seed:all

AS: administrator
I Want: to populate the database table Categories
To: test the app

## Evidence:
![categories-1](https://user-images.githubusercontent.com/112339651/200606052-1e1cc086-e931-4d9d-a121-4435ebe69d0d.png)

